### PR TITLE
feat: add structured auth audit events with ClickHouse publisher hook

### DIFF
--- a/src/main/java/com/optimaxx/management/security/audit/AuditEventType.java
+++ b/src/main/java/com/optimaxx/management/security/audit/AuditEventType.java
@@ -1,0 +1,14 @@
+package com.optimaxx.management.security.audit;
+
+public enum AuditEventType {
+    LOGIN_SUCCESS,
+    LOGIN_FAILED,
+    LOGIN_BLOCKED,
+    TOKEN_REFRESHED,
+    LOGOUT,
+    PASSWORD_CHANGED,
+    USER_CREATED,
+    USER_ROLE_UPDATED,
+    USER_STATUS_UPDATED,
+    USER_SOFT_DELETED
+}

--- a/src/main/java/com/optimaxx/management/security/audit/ClickhouseAuditPublisher.java
+++ b/src/main/java/com/optimaxx/management/security/audit/ClickhouseAuditPublisher.java
@@ -1,0 +1,8 @@
+package com.optimaxx.management.security.audit;
+
+import com.optimaxx.management.domain.model.ActivityLog;
+
+public interface ClickhouseAuditPublisher {
+
+    void publish(ActivityLog activityLog);
+}

--- a/src/main/java/com/optimaxx/management/security/audit/NoopClickhouseAuditPublisher.java
+++ b/src/main/java/com/optimaxx/management/security/audit/NoopClickhouseAuditPublisher.java
@@ -1,0 +1,13 @@
+package com.optimaxx.management.security.audit;
+
+import com.optimaxx.management.domain.model.ActivityLog;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoopClickhouseAuditPublisher implements ClickhouseAuditPublisher {
+
+    @Override
+    public void publish(ActivityLog activityLog) {
+        // TODO: Replace with a concrete ClickHouse writer integration.
+    }
+}

--- a/src/main/java/com/optimaxx/management/security/audit/SecurityAuditService.java
+++ b/src/main/java/com/optimaxx/management/security/audit/SecurityAuditService.java
@@ -1,0 +1,41 @@
+package com.optimaxx.management.security.audit;
+
+import com.optimaxx.management.domain.model.ActivityLog;
+import com.optimaxx.management.domain.model.User;
+import com.optimaxx.management.domain.repository.ActivityLogRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SecurityAuditService {
+
+    private final ActivityLogRepository activityLogRepository;
+    private final ClickhouseAuditPublisher clickhouseAuditPublisher;
+
+    public SecurityAuditService(ActivityLogRepository activityLogRepository,
+                                ClickhouseAuditPublisher clickhouseAuditPublisher) {
+        this.activityLogRepository = activityLogRepository;
+        this.clickhouseAuditPublisher = clickhouseAuditPublisher;
+    }
+
+    public void log(AuditEventType eventType, User actorUser, String resourceType, String resourceId, String afterJson) {
+        ActivityLog activityLog = new ActivityLog();
+        activityLog.setActorUserId(actorUser == null ? UUID.randomUUID() : actorUser.getId() == null ? UUID.randomUUID() : actorUser.getId());
+        activityLog.setActorRole(actorUser == null || actorUser.getRole() == null ? "SYSTEM" : actorUser.getRole().name());
+        activityLog.setAction(eventType.name());
+        activityLog.setResourceType(resourceType);
+        activityLog.setResourceId(resourceId == null ? "n/a" : resourceId);
+        activityLog.setBeforeJson("{}");
+        activityLog.setAfterJson(afterJson == null ? "{}" : afterJson);
+        activityLog.setRequestId(UUID.randomUUID().toString());
+        activityLog.setIpAddress(null);
+        activityLog.setUserAgent(null);
+        activityLog.setOccurredAt(Instant.now());
+        activityLog.setStoreId(actorUser == null || actorUser.getStoreId() == null ? UUID.randomUUID() : actorUser.getStoreId());
+        activityLog.setDeleted(false);
+
+        ActivityLog saved = activityLogRepository.save(activityLog);
+        clickhouseAuditPublisher.publish(saved);
+    }
+}

--- a/src/test/java/com/optimaxx/management/AuthIntegrationTest.java
+++ b/src/test/java/com/optimaxx/management/AuthIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.optimaxx.management.domain.model.RefreshToken;
 import com.optimaxx.management.domain.model.User;
 import com.optimaxx.management.domain.model.UserRole;
+import com.optimaxx.management.domain.repository.ActivityLogRepository;
 import com.optimaxx.management.domain.repository.RefreshTokenRepository;
 import com.optimaxx.management.domain.repository.UserRepository;
 import com.optimaxx.management.security.LoginAttemptService;
@@ -60,6 +61,9 @@ class AuthIntegrationTest {
 
     @MockitoBean
     private PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    private ActivityLogRepository activityLogRepository;
 
     private MockMvc mockMvc;
     private final Map<String, RefreshToken> refreshTokenStore = new ConcurrentHashMap<>();

--- a/src/test/java/com/optimaxx/management/AuthServiceTest.java
+++ b/src/test/java/com/optimaxx/management/AuthServiceTest.java
@@ -20,6 +20,7 @@ import com.optimaxx.management.interfaces.rest.dto.AuthRefreshRequest;
 import com.optimaxx.management.security.AuthService;
 import com.optimaxx.management.security.LoginAttemptService;
 import com.optimaxx.management.security.LoginProtectionProperties;
+import com.optimaxx.management.security.audit.SecurityAuditService;
 import com.optimaxx.management.security.jwt.JwtProperties;
 import com.optimaxx.management.security.jwt.JwtTokenService;
 import java.time.Instant;
@@ -53,7 +54,8 @@ class AuthServiceTest {
                 passwordEncoder,
                 createLoginAttemptService(),
                 jwtTokenService,
-                jwtProperties
+                jwtProperties,
+                Mockito.mock(SecurityAuditService.class)
         );
 
         AuthLoginResponse response = authService.login(new AuthLoginRequest("owner", "owner123"));
@@ -110,7 +112,8 @@ class AuthServiceTest {
                 passwordEncoder,
                 createLoginAttemptService(),
                 jwtTokenService,
-                jwtProperties
+                jwtProperties,
+                Mockito.mock(SecurityAuditService.class)
         );
 
         assertThatThrownBy(() -> authService.login(new AuthLoginRequest(" ", " ")))
@@ -143,7 +146,8 @@ class AuthServiceTest {
                 passwordEncoder,
                 createLoginAttemptService(),
                 jwtTokenService,
-                jwtProperties
+                jwtProperties,
+                Mockito.mock(SecurityAuditService.class)
         );
 
         AuthLoginResponse response = authService.refresh(new AuthRefreshRequest("raw-refresh-token"));
@@ -168,7 +172,7 @@ class AuthServiceTest {
         when(passwordEncoder.matches("owner123", "hashed")).thenReturn(true);
         when(passwordEncoder.encode("newPassword123")).thenReturn("new-hash");
 
-        AuthService authService = new AuthService(userRepository, refreshTokenRepository, passwordEncoder, createLoginAttemptService(), jwtTokenService, jwtProperties);
+        AuthService authService = new AuthService(userRepository, refreshTokenRepository, passwordEncoder, createLoginAttemptService(), jwtTokenService, jwtProperties, Mockito.mock(SecurityAuditService.class));
 
         authService.changePassword("owner", new AuthChangePasswordRequest("owner123", "newPassword123"));
 
@@ -188,7 +192,7 @@ class AuthServiceTest {
         when(userRepository.findByUsernameAndDeletedFalse("owner")).thenReturn(Optional.of(user));
         when(passwordEncoder.matches("wrong", "hashed")).thenReturn(false);
 
-        AuthService authService = new AuthService(userRepository, refreshTokenRepository, passwordEncoder, createLoginAttemptService(), jwtTokenService, jwtProperties);
+        AuthService authService = new AuthService(userRepository, refreshTokenRepository, passwordEncoder, createLoginAttemptService(), jwtTokenService, jwtProperties, Mockito.mock(SecurityAuditService.class));
 
         assertThatThrownBy(() -> authService.changePassword("owner", new AuthChangePasswordRequest("wrong", "newPassword123")))
                 .isInstanceOf(BadCredentialsException.class);
@@ -214,7 +218,8 @@ class AuthServiceTest {
                 passwordEncoder,
                 loginAttemptService,
                 jwtTokenService,
-                jwtProperties
+                jwtProperties,
+                Mockito.mock(SecurityAuditService.class)
         );
     }
 

--- a/src/test/java/com/optimaxx/management/OptiMaxxManagementApplicationTests.java
+++ b/src/test/java/com/optimaxx/management/OptiMaxxManagementApplicationTests.java
@@ -1,5 +1,6 @@
 package com.optimaxx.management;
 
+import com.optimaxx.management.domain.repository.ActivityLogRepository;
 import com.optimaxx.management.domain.repository.RefreshTokenRepository;
 import com.optimaxx.management.domain.repository.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,9 @@ class OptiMaxxManagementApplicationTests {
 
     @MockitoBean
     private RefreshTokenRepository refreshTokenRepository;
+
+    @MockitoBean
+    private ActivityLogRepository activityLogRepository;
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/optimaxx/management/UserManagementServiceTest.java
+++ b/src/test/java/com/optimaxx/management/UserManagementServiceTest.java
@@ -13,6 +13,7 @@ import com.optimaxx.management.interfaces.rest.dto.AdminCreateUserRequest;
 import com.optimaxx.management.interfaces.rest.dto.UserResponse;
 import com.optimaxx.management.security.BootstrapOwnerProperties;
 import com.optimaxx.management.security.UserManagementService;
+import com.optimaxx.management.security.audit.SecurityAuditService;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ class UserManagementServiceTest {
             return user;
         });
 
-        UserManagementService service = new UserManagementService(userRepository, passwordEncoder, bootstrapOwnerProperties);
+        UserManagementService service = new UserManagementService(userRepository, passwordEncoder, bootstrapOwnerProperties, Mockito.mock(SecurityAuditService.class));
 
         UserResponse response = service.createUser(
                 new AdminCreateUserRequest("staff", "staff@optimaxx.local", "strong123", UserRole.STAFF, true)
@@ -56,7 +57,7 @@ class UserManagementServiceTest {
 
         when(userRepository.existsByUsernameAndDeletedFalse("staff")).thenReturn(true);
 
-        UserManagementService service = new UserManagementService(userRepository, passwordEncoder, bootstrapOwnerProperties);
+        UserManagementService service = new UserManagementService(userRepository, passwordEncoder, bootstrapOwnerProperties, Mockito.mock(SecurityAuditService.class));
 
         assertThatThrownBy(() -> service.createUser(
                 new AdminCreateUserRequest("staff", "staff@optimaxx.local", "strong123", UserRole.STAFF, true)
@@ -79,7 +80,7 @@ class UserManagementServiceTest {
         UUID userId = UUID.randomUUID();
         when(userRepository.findByIdAndDeletedFalse(userId)).thenReturn(Optional.of(user));
 
-        UserManagementService service = new UserManagementService(userRepository, passwordEncoder, bootstrapOwnerProperties);
+        UserManagementService service = new UserManagementService(userRepository, passwordEncoder, bootstrapOwnerProperties, Mockito.mock(SecurityAuditService.class));
 
         UserResponse response = service.updateRole(userId, UserRole.ADMIN);
 
@@ -109,7 +110,7 @@ class UserManagementServiceTest {
         when(userRepository.findByIdAndDeletedFalse(targetId)).thenReturn(Optional.of(target));
         when(userRepository.findByUsernameAndDeletedFalse("admin1")).thenReturn(Optional.of(actor));
 
-        UserManagementService service = new UserManagementService(userRepository, passwordEncoder, bootstrapOwnerProperties);
+        UserManagementService service = new UserManagementService(userRepository, passwordEncoder, bootstrapOwnerProperties, Mockito.mock(SecurityAuditService.class));
 
         service.softDeleteUser(targetId, "admin1");
 
@@ -134,7 +135,7 @@ class UserManagementServiceTest {
         when(userRepository.findByIdAndDeletedFalse(targetId)).thenReturn(Optional.of(actorAndTarget));
         when(userRepository.findByUsernameAndDeletedFalse("owner1")).thenReturn(Optional.of(actorAndTarget));
 
-        UserManagementService service = new UserManagementService(userRepository, passwordEncoder, bootstrapOwnerProperties);
+        UserManagementService service = new UserManagementService(userRepository, passwordEncoder, bootstrapOwnerProperties, Mockito.mock(SecurityAuditService.class));
 
         assertThatThrownBy(() -> service.softDeleteUser(targetId, "owner1"))
                 .isInstanceOf(ResponseStatusException.class);


### PR DESCRIPTION
- Added audit event types and a dedicated SecurityAuditService for structured auth/user lifecycle records.

- Added a ClickHouse publisher interface with a no-op implementation to keep a clear extension point for analytics export.

- Updated AuthService and UserManagementService to emit audit events for login, lock, refresh, logout, password change, and user admin actions.

- Updated unit/integration/context tests to cover new constructor dependencies and preserve isolated test runtime.

- Tests: ./mvnw test (passed)