### PR TITLE
feat: implement ClickHouse audit writer with resilient fallback

### DIFF
--- a/src/main/java/com/optimaxx/management/security/audit/ClickhouseAuditConfig.java
+++ b/src/main/java/com/optimaxx/management/security/audit/ClickhouseAuditConfig.java
@@ -1,0 +1,9 @@
+package com.optimaxx.management.security.audit;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ClickhouseProperties.class)
+public class ClickhouseAuditConfig {
+}

--- a/src/main/java/com/optimaxx/management/security/audit/ClickhouseProperties.java
+++ b/src/main/java/com/optimaxx/management/security/audit/ClickhouseProperties.java
@@ -1,0 +1,7 @@
+package com.optimaxx.management.security.audit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "clickhouse")
+public record ClickhouseProperties(String url, String username, String password) {
+}

--- a/src/main/java/com/optimaxx/management/security/audit/NoopClickhouseAuditPublisher.java
+++ b/src/main/java/com/optimaxx/management/security/audit/NoopClickhouseAuditPublisher.java
@@ -1,13 +1,103 @@
 package com.optimaxx.management.security.audit;
 
 import com.optimaxx.management.domain.model.ActivityLog;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class NoopClickhouseAuditPublisher implements ClickhouseAuditPublisher {
 
+    private static final Logger log = LoggerFactory.getLogger(NoopClickhouseAuditPublisher.class);
+    private static final String INSERT_QUERY = "INSERT INTO audit_events FORMAT JSONEachRow";
+
+    private final ClickhouseProperties clickhouseProperties;
+    private final HttpClient httpClient;
+
+    public NoopClickhouseAuditPublisher(ClickhouseProperties clickhouseProperties) {
+        this.clickhouseProperties = clickhouseProperties;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(2))
+                .build();
+    }
+
     @Override
     public void publish(ActivityLog activityLog) {
-        // TODO: Replace with a concrete ClickHouse writer integration.
+        if (activityLog == null || isBlank(clickhouseProperties.url())) {
+            return;
+        }
+
+        String payload = toJsonEachRow(activityLog);
+        String endpoint = clickhouseProperties.url() + "?query=" + URLEncoder.encode(INSERT_QUERY, StandardCharsets.UTF_8);
+
+        try {
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                    .uri(URI.create(endpoint))
+                    .timeout(Duration.ofSeconds(3))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(payload));
+
+            if (!isBlank(clickhouseProperties.username())) {
+                String password = clickhouseProperties.password() == null ? "" : clickhouseProperties.password();
+                String credentials = clickhouseProperties.username() + ":" + password;
+                requestBuilder.header("Authorization", "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8)));
+            }
+
+            HttpResponse<String> response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 300) {
+                log.warn("ClickHouse audit publish failed with status {}: {}", response.statusCode(), response.body());
+            }
+        } catch (IOException | InterruptedException ex) {
+            if (ex instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            log.warn("ClickHouse audit publish failed: {}", ex.getMessage());
+        }
+    }
+
+    private String toJsonEachRow(ActivityLog logItem) {
+        return "{" +
+                "\"event_id\":\"" + safe(logItem.getId()) + "\"," +
+                "\"timestamp\":\"" + safe(logItem.getOccurredAt()) + "\"," +
+                "\"actor_user_id\":\"" + safe(logItem.getActorUserId()) + "\"," +
+                "\"actor_role\":\"" + escape(logItem.getActorRole()) + "\"," +
+                "\"action\":\"" + escape(logItem.getAction()) + "\"," +
+                "\"resource_type\":\"" + escape(logItem.getResourceType()) + "\"," +
+                "\"resource_id\":\"" + escape(logItem.getResourceId()) + "\"," +
+                "\"before_json\":\"" + escape(logItem.getBeforeJson()) + "\"," +
+                "\"after_json\":\"" + escape(logItem.getAfterJson()) + "\"," +
+                "\"request_id\":\"" + escape(logItem.getRequestId()) + "\"," +
+                "\"ip_address\":\"" + escape(logItem.getIpAddress()) + "\"," +
+                "\"user_agent\":\"" + escape(logItem.getUserAgent()) + "\"," +
+                "\"store_id\":\"" + safe(logItem.getStoreId()) + "\"" +
+                "}";
+    }
+
+    private String safe(Object value) {
+        return value == null ? "" : escape(String.valueOf(value));
+    }
+
+    private String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r");
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/test/java/com/optimaxx/management/ClickhouseAuditPublisherTest.java
+++ b/src/test/java/com/optimaxx/management/ClickhouseAuditPublisherTest.java
@@ -1,0 +1,33 @@
+package com.optimaxx.management;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.optimaxx.management.domain.model.ActivityLog;
+import com.optimaxx.management.security.audit.ClickhouseProperties;
+import com.optimaxx.management.security.audit.NoopClickhouseAuditPublisher;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ClickhouseAuditPublisherTest {
+
+    @Test
+    void shouldNotThrowWhenClickhouseEndpointIsUnavailable() {
+        ClickhouseProperties properties = new ClickhouseProperties("http://localhost:65534/default", "default", "");
+        NoopClickhouseAuditPublisher publisher = new NoopClickhouseAuditPublisher(properties);
+
+        ActivityLog activityLog = new ActivityLog();
+        activityLog.setActorUserId(UUID.randomUUID());
+        activityLog.setActorRole("OWNER");
+        activityLog.setAction("LOGIN_SUCCESS");
+        activityLog.setResourceType("AUTH");
+        activityLog.setResourceId("owner");
+        activityLog.setBeforeJson("{}");
+        activityLog.setAfterJson("{}");
+        activityLog.setRequestId(UUID.randomUUID().toString());
+        activityLog.setOccurredAt(Instant.now());
+        activityLog.setStoreId(UUID.randomUUID());
+
+        assertThatCode(() -> publisher.publish(activityLog)).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
- Added ClickHouse audit configuration properties and wiring via configuration properties support.

- Replaced the no-op publisher behavior with HTTP JSONEachRow inserts to audit_events, including optional basic auth support.

- Kept publisher failure-safe: network/HTTP errors are logged and do not break auth flows.

- Added unit coverage for unavailable ClickHouse endpoint behavior and updated affected service tests.

- Tests: ./mvnw test (passed)