### PR TITLE
feat: enrich audit events with request context metadata

### DIFF
--- a/src/main/java/com/optimaxx/management/security/audit/SecurityAuditService.java
+++ b/src/main/java/com/optimaxx/management/security/audit/SecurityAuditService.java
@@ -3,12 +3,18 @@ package com.optimaxx.management.security.audit;
 import com.optimaxx.management.domain.model.ActivityLog;
 import com.optimaxx.management.domain.model.User;
 import com.optimaxx.management.domain.repository.ActivityLogRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.Instant;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Service
 public class SecurityAuditService {
+
+    private static final String REQUEST_ID_ATTRIBUTE = "request_id";
 
     private final ActivityLogRepository activityLogRepository;
     private final ClickhouseAuditPublisher clickhouseAuditPublisher;
@@ -20,6 +26,8 @@ public class SecurityAuditService {
     }
 
     public void log(AuditEventType eventType, User actorUser, String resourceType, String resourceId, String afterJson) {
+        HttpServletRequest request = currentRequest();
+
         ActivityLog activityLog = new ActivityLog();
         activityLog.setActorUserId(actorUser == null ? UUID.randomUUID() : actorUser.getId() == null ? UUID.randomUUID() : actorUser.getId());
         activityLog.setActorRole(actorUser == null || actorUser.getRole() == null ? "SYSTEM" : actorUser.getRole().name());
@@ -28,14 +36,61 @@ public class SecurityAuditService {
         activityLog.setResourceId(resourceId == null ? "n/a" : resourceId);
         activityLog.setBeforeJson("{}");
         activityLog.setAfterJson(afterJson == null ? "{}" : afterJson);
-        activityLog.setRequestId(UUID.randomUUID().toString());
-        activityLog.setIpAddress(null);
-        activityLog.setUserAgent(null);
+        activityLog.setRequestId(resolveRequestId(request));
+        activityLog.setIpAddress(resolveIpAddress(request));
+        activityLog.setUserAgent(resolveUserAgent(request));
         activityLog.setOccurredAt(Instant.now());
         activityLog.setStoreId(actorUser == null || actorUser.getStoreId() == null ? UUID.randomUUID() : actorUser.getStoreId());
         activityLog.setDeleted(false);
 
         ActivityLog saved = activityLogRepository.save(activityLog);
         clickhouseAuditPublisher.publish(saved);
+    }
+
+    private HttpServletRequest currentRequest() {
+        RequestAttributes attrs = RequestContextHolder.getRequestAttributes();
+        if (attrs instanceof ServletRequestAttributes servletAttrs) {
+            return servletAttrs.getRequest();
+        }
+        return null;
+    }
+
+    private String resolveRequestId(HttpServletRequest request) {
+        if (request == null) {
+            return UUID.randomUUID().toString();
+        }
+
+        Object existing = request.getAttribute(REQUEST_ID_ATTRIBUTE);
+        if (existing instanceof String existingRequestId && !existingRequestId.isBlank()) {
+            return existingRequestId;
+        }
+
+        String fromHeader = request.getHeader("X-Request-Id");
+        String requestId = (fromHeader == null || fromHeader.isBlank()) ? UUID.randomUUID().toString() : fromHeader;
+        request.setAttribute(REQUEST_ID_ATTRIBUTE, requestId);
+        return requestId;
+    }
+
+    private String resolveIpAddress(HttpServletRequest request) {
+        if (request == null) {
+            return null;
+        }
+
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            int commaIndex = forwarded.indexOf(',');
+            return commaIndex > 0 ? forwarded.substring(0, commaIndex).trim() : forwarded.trim();
+        }
+
+        String realIp = request.getHeader("X-Real-IP");
+        if (realIp != null && !realIp.isBlank()) {
+            return realIp.trim();
+        }
+
+        return request.getRemoteAddr();
+    }
+
+    private String resolveUserAgent(HttpServletRequest request) {
+        return request == null ? null : request.getHeader("User-Agent");
     }
 }

--- a/src/test/java/com/optimaxx/management/SecurityAuditServiceTest.java
+++ b/src/test/java/com/optimaxx/management/SecurityAuditServiceTest.java
@@ -1,0 +1,79 @@
+package com.optimaxx.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.optimaxx.management.domain.model.ActivityLog;
+import com.optimaxx.management.domain.model.User;
+import com.optimaxx.management.domain.model.UserRole;
+import com.optimaxx.management.domain.repository.ActivityLogRepository;
+import com.optimaxx.management.security.audit.AuditEventType;
+import com.optimaxx.management.security.audit.ClickhouseAuditPublisher;
+import com.optimaxx.management.security.audit.SecurityAuditService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class SecurityAuditServiceTest {
+
+    @AfterEach
+    void cleanContext() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void shouldCaptureRequestContextIntoAuditLog() {
+        ActivityLogRepository activityLogRepository = Mockito.mock(ActivityLogRepository.class);
+        ClickhouseAuditPublisher clickhouseAuditPublisher = Mockito.mock(ClickhouseAuditPublisher.class);
+
+        when(activityLogRepository.save(any(ActivityLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SecurityAuditService securityAuditService = new SecurityAuditService(activityLogRepository, clickhouseAuditPublisher);
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        when(request.getHeader("X-Request-Id")).thenReturn("req-123");
+        when(request.getHeader("X-Forwarded-For")).thenReturn("203.0.113.10, 10.0.0.1");
+        when(request.getHeader("User-Agent")).thenReturn("JUnit-Agent");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        User actor = new User();
+        actor.setUsername("owner");
+        actor.setRole(UserRole.OWNER);
+        actor.setStoreId(UUID.randomUUID());
+
+        securityAuditService.log(AuditEventType.LOGIN_SUCCESS, actor, "AUTH", "owner", "{\"status\":\"success\"}");
+
+        verify(activityLogRepository).save(any(ActivityLog.class));
+        verify(clickhouseAuditPublisher).publish(any(ActivityLog.class));
+        verify(request).setAttribute("request_id", "req-123");
+    }
+
+    @Test
+    void shouldGenerateRequestIdWhenHeaderMissing() {
+        ActivityLogRepository activityLogRepository = Mockito.mock(ActivityLogRepository.class);
+        ClickhouseAuditPublisher clickhouseAuditPublisher = Mockito.mock(ClickhouseAuditPublisher.class);
+
+        when(activityLogRepository.save(any(ActivityLog.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SecurityAuditService securityAuditService = new SecurityAuditService(activityLogRepository, clickhouseAuditPublisher);
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        when(request.getHeader("X-Request-Id")).thenReturn(null);
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("X-Real-IP")).thenReturn("198.51.100.5");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        securityAuditService.log(AuditEventType.LOGIN_FAILED, null, "AUTH", "unknown", "{}");
+
+        verify(request).setAttribute(Mockito.eq("request_id"), Mockito.argThat(value -> {
+            assertThat(String.valueOf(value)).isNotBlank();
+            return true;
+        }));
+    }
+}


### PR DESCRIPTION
- Updated SecurityAuditService to capture request_id, ip_address, and user_agent from current HTTP request context.

- Added deterministic request-id behavior: use X-Request-Id when provided, otherwise generate and cache per request.

- Added request-context-focused unit coverage for audit metadata extraction and fallback behavior.

- Preserved existing auth/user audit flow while improving forensic traceability of events.

- Tests: ./mvnw test (passed)