### PR TITLE
feat: add retry buffer for resilient ClickHouse audit delivery

### DIFF
--- a/src/main/java/com/optimaxx/management/security/audit/ClickhouseAuditConfig.java
+++ b/src/main/java/com/optimaxx/management/security/audit/ClickhouseAuditConfig.java
@@ -2,8 +2,10 @@ package com.optimaxx.management.security.audit;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
-@EnableConfigurationProperties(ClickhouseProperties.class)
+@EnableScheduling
+@EnableConfigurationProperties({ClickhouseProperties.class, ClickhouseAuditRetryProperties.class})
 public class ClickhouseAuditConfig {
 }

--- a/src/main/java/com/optimaxx/management/security/audit/ClickhouseAuditRetryProperties.java
+++ b/src/main/java/com/optimaxx/management/security/audit/ClickhouseAuditRetryProperties.java
@@ -1,0 +1,44 @@
+package com.optimaxx.management.security.audit;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "clickhouse.audit.retry")
+public class ClickhouseAuditRetryProperties {
+
+    private int maxQueueSize = 1000;
+    private int maxAttempts = 5;
+    private long fixedDelayMs = 5000;
+    private int flushBatchSize = 100;
+
+    public int getMaxQueueSize() {
+        return maxQueueSize;
+    }
+
+    public void setMaxQueueSize(int maxQueueSize) {
+        this.maxQueueSize = maxQueueSize;
+    }
+
+    public int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    public void setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    public long getFixedDelayMs() {
+        return fixedDelayMs;
+    }
+
+    public void setFixedDelayMs(long fixedDelayMs) {
+        this.fixedDelayMs = fixedDelayMs;
+    }
+
+    public int getFlushBatchSize() {
+        return flushBatchSize;
+    }
+
+    public void setFlushBatchSize(int flushBatchSize) {
+        this.flushBatchSize = flushBatchSize;
+    }
+}

--- a/src/test/java/com/optimaxx/management/ClickhouseAuditPublisherTest.java
+++ b/src/test/java/com/optimaxx/management/ClickhouseAuditPublisherTest.java
@@ -1,8 +1,10 @@
 package com.optimaxx.management;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.optimaxx.management.domain.model.ActivityLog;
+import com.optimaxx.management.security.audit.ClickhouseAuditRetryProperties;
 import com.optimaxx.management.security.audit.ClickhouseProperties;
 import com.optimaxx.management.security.audit.NoopClickhouseAuditPublisher;
 import java.time.Instant;
@@ -14,8 +16,34 @@ class ClickhouseAuditPublisherTest {
     @Test
     void shouldNotThrowWhenClickhouseEndpointIsUnavailable() {
         ClickhouseProperties properties = new ClickhouseProperties("http://localhost:65534/default", "default", "");
-        NoopClickhouseAuditPublisher publisher = new NoopClickhouseAuditPublisher(properties);
+        ClickhouseAuditRetryProperties retryProperties = new ClickhouseAuditRetryProperties();
+        NoopClickhouseAuditPublisher publisher = new NoopClickhouseAuditPublisher(properties, retryProperties);
 
+        ActivityLog activityLog = createActivityLog();
+
+        assertThatCode(() -> publisher.publish(activityLog)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldQueueFailedAuditForRetry() {
+        ClickhouseProperties properties = new ClickhouseProperties("http://localhost:65534/default", "default", "");
+        ClickhouseAuditRetryProperties retryProperties = new ClickhouseAuditRetryProperties();
+        retryProperties.setMaxQueueSize(10);
+        retryProperties.setMaxAttempts(2);
+        retryProperties.setFlushBatchSize(5);
+
+        NoopClickhouseAuditPublisher publisher = new NoopClickhouseAuditPublisher(properties, retryProperties);
+
+        publisher.publish(createActivityLog());
+
+        assertThat(publisher.getPendingQueueSize()).isGreaterThan(0);
+
+        publisher.flushRetryQueue();
+
+        assertThat(publisher.getDroppedCount()).isGreaterThanOrEqualTo(0);
+    }
+
+    private ActivityLog createActivityLog() {
         ActivityLog activityLog = new ActivityLog();
         activityLog.setActorUserId(UUID.randomUUID());
         activityLog.setActorRole("OWNER");
@@ -27,7 +55,6 @@ class ClickhouseAuditPublisherTest {
         activityLog.setRequestId(UUID.randomUUID().toString());
         activityLog.setOccurredAt(Instant.now());
         activityLog.setStoreId(UUID.randomUUID());
-
-        assertThatCode(() -> publisher.publish(activityLog)).doesNotThrowAnyException();
+        return activityLog;
     }
 }


### PR DESCRIPTION
- Added configurable retry properties for ClickHouse audit buffering (queue size, attempts, delay, batch size).

- Enabled scheduled retry flushing and implemented bounded in-memory queue with drop accounting.

- Updated publisher flow to enqueue failed writes and retry asynchronously without breaking auth requests.

- Added test coverage for queueing behavior when ClickHouse endpoint is unavailable.

- Tests: ./mvnw test (passed)