### PR TITLE
feat: add admin observability endpoint for audit retry buffer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,10 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/optimaxx/management/interfaces/rest/AdminAuditController.java
+++ b/src/main/java/com/optimaxx/management/interfaces/rest/AdminAuditController.java
@@ -1,0 +1,29 @@
+package com.optimaxx.management.interfaces.rest;
+
+import com.optimaxx.management.interfaces.rest.dto.AuditRetryStatusResponse;
+import com.optimaxx.management.security.audit.NoopClickhouseAuditPublisher;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/audit")
+public class AdminAuditController {
+
+    private final NoopClickhouseAuditPublisher auditPublisher;
+
+    public AdminAuditController(NoopClickhouseAuditPublisher auditPublisher) {
+        this.auditPublisher = auditPublisher;
+    }
+
+    @GetMapping("/retry-status")
+    public AuditRetryStatusResponse getRetryStatus() {
+        return new AuditRetryStatusResponse(
+                auditPublisher.getPendingQueueSize(),
+                auditPublisher.getDroppedCount(),
+                auditPublisher.getPublishFailureCount(),
+                auditPublisher.getRetryAttemptCount(),
+                auditPublisher.getPublishedSuccessCount()
+        );
+    }
+}

--- a/src/main/java/com/optimaxx/management/interfaces/rest/dto/AuditRetryStatusResponse.java
+++ b/src/main/java/com/optimaxx/management/interfaces/rest/dto/AuditRetryStatusResponse.java
@@ -1,0 +1,10 @@
+package com.optimaxx.management.interfaces.rest.dto;
+
+public record AuditRetryStatusResponse(
+        int pendingQueueSize,
+        long droppedCount,
+        long publishFailureCount,
+        long retryAttemptCount,
+        long publishedSuccessCount
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,metrics,prometheus
   endpoint:
     health:
       show-details: always

--- a/src/test/java/com/optimaxx/management/AuthIntegrationTest.java
+++ b/src/test/java/com/optimaxx/management/AuthIntegrationTest.java
@@ -206,6 +206,20 @@ class AuthIntegrationTest {
     }
 
     @Test
+    void shouldReturnAuditRetryStatusForOwnerRole() throws Exception {
+        String ownerToken = jwtTokenService.generateAccessToken("owner", "OWNER");
+
+        mockMvc.perform(get("/api/v1/admin/audit/retry-status")
+                        .header("Authorization", "Bearer " + ownerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pendingQueueSize").exists())
+                .andExpect(jsonPath("$.droppedCount").exists())
+                .andExpect(jsonPath("$.publishFailureCount").exists())
+                .andExpect(jsonPath("$.retryAttemptCount").exists())
+                .andExpect(jsonPath("$.publishedSuccessCount").exists());
+    }
+
+    @Test
     void shouldRejectSelfDeleteForOwner() throws Exception {
         User owner = new User();
         UUID ownerId = UUID.randomUUID();

--- a/src/test/java/com/optimaxx/management/ClickhouseAuditPublisherTest.java
+++ b/src/test/java/com/optimaxx/management/ClickhouseAuditPublisherTest.java
@@ -7,6 +7,7 @@ import com.optimaxx.management.domain.model.ActivityLog;
 import com.optimaxx.management.security.audit.ClickhouseAuditRetryProperties;
 import com.optimaxx.management.security.audit.ClickhouseProperties;
 import com.optimaxx.management.security.audit.NoopClickhouseAuditPublisher;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ class ClickhouseAuditPublisherTest {
     void shouldNotThrowWhenClickhouseEndpointIsUnavailable() {
         ClickhouseProperties properties = new ClickhouseProperties("http://localhost:65534/default", "default", "");
         ClickhouseAuditRetryProperties retryProperties = new ClickhouseAuditRetryProperties();
-        NoopClickhouseAuditPublisher publisher = new NoopClickhouseAuditPublisher(properties, retryProperties);
+        NoopClickhouseAuditPublisher publisher = new NoopClickhouseAuditPublisher(properties, retryProperties, new SimpleMeterRegistry());
 
         ActivityLog activityLog = createActivityLog();
 
@@ -32,7 +33,7 @@ class ClickhouseAuditPublisherTest {
         retryProperties.setMaxAttempts(2);
         retryProperties.setFlushBatchSize(5);
 
-        NoopClickhouseAuditPublisher publisher = new NoopClickhouseAuditPublisher(properties, retryProperties);
+        NoopClickhouseAuditPublisher publisher = new NoopClickhouseAuditPublisher(properties, retryProperties, new SimpleMeterRegistry());
 
         publisher.publish(createActivityLog());
 


### PR DESCRIPTION
- Added admin endpoint /api/v1/admin/audit/retry-status to expose queue and retry health metrics.

- Added retry telemetry counters (publish failures, retry attempts, successful publishes) in ClickHouse audit publisher.

- Added Micrometer gauges for pending queue size and dropped event count for Prometheus/Actuator scraping.

- Enabled metrics and prometheus actuator exposure in application defaults and added Prometheus registry dependency.

- Tests: ./mvnw test (passed)