### PR TITLE
feat: bind refresh token lifecycle to device context

### DIFF
--- a/src/main/java/com/optimaxx/management/domain/model/RefreshToken.java
+++ b/src/main/java/com/optimaxx/management/domain/model/RefreshToken.java
@@ -31,6 +31,15 @@ public class RefreshToken {
     @Column(name = "expires_at", nullable = false)
     private Instant expiresAt;
 
+    @Column(name = "device_id", nullable = false)
+    private String deviceId;
+
+    @Column(name = "user_agent")
+    private String userAgent;
+
+    @Column(name = "ip_address")
+    private String ipAddress;
+
     @Column(name = "revoked", nullable = false)
     private boolean revoked;
 
@@ -73,6 +82,30 @@ public class RefreshToken {
 
     public void setExpiresAt(Instant expiresAt) {
         this.expiresAt = expiresAt;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
     }
 
     public boolean isRevoked() {

--- a/src/main/java/com/optimaxx/management/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/optimaxx/management/domain/repository/RefreshTokenRepository.java
@@ -1,7 +1,9 @@
 package com.optimaxx.management.domain.repository;
 
 import com.optimaxx.management.domain.model.RefreshToken;
+import com.optimaxx.management.domain.model.User;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +11,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
 
     Optional<RefreshToken> findByTokenHashAndRevokedFalseAndExpiresAtAfter(String tokenHash, Instant now);
+
+    List<RefreshToken> findByUserAndRevokedFalseAndExpiresAtAfter(User user, Instant now);
 }

--- a/src/main/java/com/optimaxx/management/interfaces/rest/AuthController.java
+++ b/src/main/java/com/optimaxx/management/interfaces/rest/AuthController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,18 +25,31 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public AuthLoginResponse login(@RequestBody AuthLoginRequest request) {
-        return authService.login(request);
+    public AuthLoginResponse login(@RequestBody AuthLoginRequest request,
+                                   @RequestHeader(value = "X-Device-Id", required = false) String deviceId,
+                                   @RequestHeader(value = "User-Agent", required = false) String userAgent,
+                                   @RequestHeader(value = "X-Forwarded-For", required = false) String forwardedFor) {
+        return authService.login(request, deviceId, userAgent, forwardedFor);
     }
 
     @PostMapping("/refresh")
-    public AuthLoginResponse refresh(@RequestBody AuthRefreshRequest request) {
-        return authService.refresh(request);
+    public AuthLoginResponse refresh(@RequestBody AuthRefreshRequest request,
+                                     @RequestHeader(value = "X-Device-Id", required = false) String deviceId,
+                                     @RequestHeader(value = "User-Agent", required = false) String userAgent,
+                                     @RequestHeader(value = "X-Forwarded-For", required = false) String forwardedFor) {
+        return authService.refresh(request, deviceId, userAgent, forwardedFor);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@RequestBody AuthLogoutRequest request) {
-        authService.logout(request == null ? null : request.refreshToken());
+    public ResponseEntity<Void> logout(@RequestBody AuthLogoutRequest request,
+                                       @RequestHeader(value = "X-Device-Id", required = false) String deviceId) {
+        authService.logout(request == null ? null : request.refreshToken(), deviceId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/logout-all")
+    public ResponseEntity<Void> logoutAll(Authentication authentication) {
+        authService.logoutAllDevices(authentication == null ? null : authentication.getName());
         return ResponseEntity.noContent().build();
     }
 


### PR DESCRIPTION
- Extended refresh token model with deviceId, userAgent, and ipAddress metadata for per-device session control.

- Updated auth login/refresh/logout flows to enforce device binding via X-Device-Id and added logout-all endpoint for user-wide session revocation.

- Added repository support for active token queries by user to enable logout-all across devices.

- Updated integration and service tests for device-aware login/refresh/logout scenarios and logout-all behavior.

- Tests: ./mvnw test (passed)