### PR TITLE
feat: add password reset migration and clean up audit publisher naming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>

--- a/src/main/java/com/optimaxx/management/interfaces/rest/AdminAuditController.java
+++ b/src/main/java/com/optimaxx/management/interfaces/rest/AdminAuditController.java
@@ -1,7 +1,7 @@
 package com.optimaxx.management.interfaces.rest;
 
 import com.optimaxx.management.interfaces.rest.dto.AuditRetryStatusResponse;
-import com.optimaxx.management.security.audit.NoopClickhouseAuditPublisher;
+import com.optimaxx.management.security.audit.ResilientClickhouseAuditPublisher;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/admin/audit")
 public class AdminAuditController {
 
-    private final NoopClickhouseAuditPublisher auditPublisher;
+    private final ResilientClickhouseAuditPublisher auditPublisher;
 
-    public AdminAuditController(NoopClickhouseAuditPublisher auditPublisher) {
+    public AdminAuditController(ResilientClickhouseAuditPublisher auditPublisher) {
         this.auditPublisher = auditPublisher;
     }
 

--- a/src/main/java/com/optimaxx/management/security/audit/ResilientClickhouseAuditPublisher.java
+++ b/src/main/java/com/optimaxx/management/security/audit/ResilientClickhouseAuditPublisher.java
@@ -21,9 +21,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
-public class NoopClickhouseAuditPublisher implements ClickhouseAuditPublisher {
+public class ResilientClickhouseAuditPublisher implements ClickhouseAuditPublisher {
 
-    private static final Logger log = LoggerFactory.getLogger(NoopClickhouseAuditPublisher.class);
+    private static final Logger log = LoggerFactory.getLogger(ResilientClickhouseAuditPublisher.class);
     private static final String INSERT_QUERY = "INSERT INTO audit_events FORMAT JSONEachRow";
 
     private final ClickhouseProperties clickhouseProperties;
@@ -35,7 +35,7 @@ public class NoopClickhouseAuditPublisher implements ClickhouseAuditPublisher {
     private final AtomicLong retryAttemptCount = new AtomicLong(0);
     private final AtomicLong publishedSuccessCount = new AtomicLong(0);
 
-    public NoopClickhouseAuditPublisher(ClickhouseProperties clickhouseProperties,
+    public ResilientClickhouseAuditPublisher(ClickhouseProperties clickhouseProperties,
                                         ClickhouseAuditRetryProperties retryProperties,
                                         MeterRegistry meterRegistry) {
         this.clickhouseProperties = clickhouseProperties;
@@ -44,7 +44,7 @@ public class NoopClickhouseAuditPublisher implements ClickhouseAuditPublisher {
                 .connectTimeout(Duration.ofSeconds(2))
                 .build();
 
-        Gauge.builder("optimaxx.audit.retry.queue.size", this, NoopClickhouseAuditPublisher::getPendingQueueSize)
+        Gauge.builder("optimaxx.audit.retry.queue.size", this, ResilientClickhouseAuditPublisher::getPendingQueueSize)
                 .description("Pending audit events waiting for ClickHouse retry")
                 .register(meterRegistry);
         Gauge.builder("optimaxx.audit.retry.dropped.count", this, p -> p.getDroppedCount())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
   threads:
     virtual:
       enabled: true
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    baseline-version: 0
 
 management:
   endpoints:

--- a/src/main/resources/db/migration/V1__create_password_reset_tokens.sql
+++ b/src/main/resources/db/migration/V1__create_password_reset_tokens.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    token_hash VARCHAR(64) NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used BOOLEAN NOT NULL DEFAULT FALSE,
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT uk_password_reset_tokens_token_hash UNIQUE (token_hash),
+    CONSTRAINT fk_password_reset_tokens_user FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens (user_id);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_expires_at ON password_reset_tokens (expires_at);

--- a/src/test/java/com/optimaxx/management/ClickhouseAuditPublisherTest.java
+++ b/src/test/java/com/optimaxx/management/ClickhouseAuditPublisherTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import com.optimaxx.management.domain.model.ActivityLog;
 import com.optimaxx.management.security.audit.ClickhouseAuditRetryProperties;
 import com.optimaxx.management.security.audit.ClickhouseProperties;
-import com.optimaxx.management.security.audit.NoopClickhouseAuditPublisher;
+import com.optimaxx.management.security.audit.ResilientClickhouseAuditPublisher;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.UUID;
@@ -18,7 +18,7 @@ class ClickhouseAuditPublisherTest {
     void shouldNotThrowWhenClickhouseEndpointIsUnavailable() {
         ClickhouseProperties properties = new ClickhouseProperties("http://localhost:65534/default", "default", "");
         ClickhouseAuditRetryProperties retryProperties = new ClickhouseAuditRetryProperties();
-        NoopClickhouseAuditPublisher publisher = new NoopClickhouseAuditPublisher(properties, retryProperties, new SimpleMeterRegistry());
+        ResilientClickhouseAuditPublisher publisher = new ResilientClickhouseAuditPublisher(properties, retryProperties, new SimpleMeterRegistry());
 
         ActivityLog activityLog = createActivityLog();
 
@@ -33,7 +33,7 @@ class ClickhouseAuditPublisherTest {
         retryProperties.setMaxAttempts(2);
         retryProperties.setFlushBatchSize(5);
 
-        NoopClickhouseAuditPublisher publisher = new NoopClickhouseAuditPublisher(properties, retryProperties, new SimpleMeterRegistry());
+        ResilientClickhouseAuditPublisher publisher = new ResilientClickhouseAuditPublisher(properties, retryProperties, new SimpleMeterRegistry());
 
         publisher.publish(createActivityLog());
 


### PR DESCRIPTION
- Added Flyway baseline configuration and V1 migration for password_reset_tokens.

- Added Flyway dependency to support production-safe schema evolution with ddl-auto validate.

- Renamed NoopClickhouseAuditPublisher to ResilientClickhouseAuditPublisher to reflect actual behavior.

- Updated admin audit endpoint and tests to use the renamed publisher class.

- Tests: ./mvnw test (passed).