### PR TITLE
feat: finalize repair reservation lifecycle transitions

### DIFF
--- a/src/main/java/com/optimaxx/management/interfaces/rest/dto/RepairOrderResponse.java
+++ b/src/main/java/com/optimaxx/management/interfaces/rest/dto/RepairOrderResponse.java
@@ -10,5 +10,8 @@ public record RepairOrderResponse(UUID id,
                                   String title,
                                   String description,
                                   RepairStatus status,
-                                  Instant receivedAt) {
+                                  Instant receivedAt,
+                                  UUID reservedInventoryItemId,
+                                  Integer reservedInventoryQuantity,
+                                  boolean inventoryReleased) {
 }


### PR DESCRIPTION
- Added repair status transition guards to block invalid lifecycle jumps.

- Kept reservation release strictly on canceled flow and prevented release on delivered flow.

- Extended repair response payload with reserved inventory visibility fields.

- Expanded repair service tests for invalid transitions, delivered behavior, and response reservation fields.

- Tests: ./mvnw test (passed).