### PR TITLE
feat: add public receipt verification endpoint for sales

### DIFF
--- a/src/main/java/com/optimaxx/management/domain/repository/SaleTransactionRepository.java
+++ b/src/main/java/com/optimaxx/management/domain/repository/SaleTransactionRepository.java
@@ -27,6 +27,8 @@ public interface SaleTransactionRepository extends JpaRepository<SaleTransaction
 
     Optional<SaleTransaction> findByIdAndDeletedFalse(UUID id);
 
+    Optional<SaleTransaction> findByReceiptNumberAndDeletedFalse(String receiptNumber);
+
     boolean existsByStoreIdAndReceiptNumberAndDeletedFalse(UUID storeId, String receiptNumber);
 
     List<SaleTransaction> findByDeletedFalseOrderByOccurredAtDesc();

--- a/src/main/java/com/optimaxx/management/interfaces/rest/SalesTransactionController.java
+++ b/src/main/java/com/optimaxx/management/interfaces/rest/SalesTransactionController.java
@@ -1,6 +1,7 @@
 package com.optimaxx.management.interfaces.rest;
 
 import com.optimaxx.management.interfaces.rest.dto.CreateSaleTransactionRequest;
+import com.optimaxx.management.interfaces.rest.dto.ReceiptVerificationResponse;
 import com.optimaxx.management.interfaces.rest.dto.RefundSaleTransactionRequest;
 import com.optimaxx.management.interfaces.rest.dto.SaleTransactionDetailResponse;
 import com.optimaxx.management.interfaces.rest.dto.SaleTransactionResponse;
@@ -49,6 +50,11 @@ public class SalesTransactionController {
                                               @RequestParam(value = "size", defaultValue = "20") int size,
                                               @RequestParam(value = "sort", defaultValue = "occurredAt,desc") String sort) {
         return salesTransactionService.list(from, to, query, paymentMethod, page, size, sort);
+    }
+
+    @GetMapping("/verify")
+    public ReceiptVerificationResponse verify(@RequestParam("receiptNumber") String receiptNumber) {
+        return salesTransactionService.verifyReceipt(receiptNumber);
     }
 
     @GetMapping("/summary")

--- a/src/main/java/com/optimaxx/management/interfaces/rest/dto/ReceiptVerificationResponse.java
+++ b/src/main/java/com/optimaxx/management/interfaces/rest/dto/ReceiptVerificationResponse.java
@@ -1,0 +1,12 @@
+package com.optimaxx.management.interfaces.rest.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record ReceiptVerificationResponse(boolean valid,
+                                          String receiptNumber,
+                                          String invoiceNumber,
+                                          BigDecimal amount,
+                                          String status,
+                                          Instant occurredAt) {
+}

--- a/src/main/java/com/optimaxx/management/security/SecurityConfig.java
+++ b/src/main/java/com/optimaxx/management/security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/actuator/health", "/api/v1/system/health").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/logout", "/api/v1/auth/forgot-password", "/api/v1/auth/reset-password").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/sales/transactions/verify").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasAnyRole("OWNER", "ADMIN")
                         .requestMatchers("/api/v1/sales/**").hasAnyRole("OWNER", "ADMIN", "STAFF")
                         .anyRequest().authenticated())

--- a/src/test/java/com/optimaxx/management/AuthIntegrationTest.java
+++ b/src/test/java/com/optimaxx/management/AuthIntegrationTest.java
@@ -824,6 +824,27 @@ class AuthIntegrationTest {
     }
 
     @Test
+    void shouldVerifyReceiptWithoutAuth() throws Exception {
+        com.optimaxx.management.domain.model.TransactionType type = new com.optimaxx.management.domain.model.TransactionType();
+        type.setCode("GLASS_SALE");
+
+        com.optimaxx.management.domain.model.SaleTransaction tx = new com.optimaxx.management.domain.model.SaleTransaction();
+        tx.setTransactionType(type);
+        tx.setReceiptNumber("RCP-20260225-0001");
+        tx.setAmount(new java.math.BigDecimal("120.00"));
+        tx.setOccurredAt(Instant.now());
+        tx.setStatus(com.optimaxx.management.domain.model.SaleTransactionStatus.COMPLETED);
+
+        when(saleTransactionRepository.findByReceiptNumberAndDeletedFalse("RCP-20260225-0001")).thenReturn(Optional.of(tx));
+
+        mockMvc.perform(get("/api/v1/sales/transactions/verify")
+                        .param("receiptNumber", "RCP-20260225-0001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valid").value(true))
+                .andExpect(jsonPath("$.receiptNumber").value("RCP-20260225-0001"));
+    }
+
+    @Test
     void shouldDownloadSalesTransactionInvoicePdfForStaffRole() throws Exception {
         String staffToken = jwtTokenService.generateAccessToken("staff1", "STAFF");
         UUID transactionId = UUID.randomUUID();

--- a/src/test/java/com/optimaxx/management/SalesTransactionServiceTest.java
+++ b/src/test/java/com/optimaxx/management/SalesTransactionServiceTest.java
@@ -264,6 +264,31 @@ class SalesTransactionServiceTest {
     }
 
     @Test
+    void shouldVerifyReceiptAsValid() {
+        SaleTransactionRepository saleRepository = Mockito.mock(SaleTransactionRepository.class);
+        TransactionTypeRepository typeRepository = Mockito.mock(TransactionTypeRepository.class);
+        CustomerRepository customerRepository = Mockito.mock(CustomerRepository.class);
+        SecurityAuditService auditService = Mockito.mock(SecurityAuditService.class);
+        ActivityLogRepository activityLogRepository = Mockito.mock(ActivityLogRepository.class);
+        InventoryStockCoordinator inventoryStockCoordinator = Mockito.mock(InventoryStockCoordinator.class);
+
+        SaleTransaction tx = new SaleTransaction();
+        tx.setReceiptNumber("RCP-20260225-0001");
+        tx.setInvoiceNumber("INV-20260225-0001");
+        tx.setAmount(new BigDecimal("200.00"));
+        tx.setStatus(SaleTransactionStatus.COMPLETED);
+        tx.setOccurredAt(Instant.now());
+
+        when(saleRepository.findByReceiptNumberAndDeletedFalse("RCP-20260225-0001")).thenReturn(Optional.of(tx));
+
+        SalesTransactionService service = new SalesTransactionService(saleRepository, typeRepository, customerRepository, activityLogRepository, auditService, inventoryStockCoordinator);
+        var response = service.verifyReceipt("RCP-20260225-0001");
+
+        assertThat(response.valid()).isTrue();
+        assertThat(response.invoiceNumber()).isEqualTo("INV-20260225-0001");
+    }
+
+    @Test
     void shouldGenerateInvoicePdf() {
         SaleTransactionRepository saleRepository = Mockito.mock(SaleTransactionRepository.class);
         TransactionTypeRepository typeRepository = Mockito.mock(TransactionTypeRepository.class);


### PR DESCRIPTION
Added GET /api/v1/sales/transactions/verify?receiptNumber=... endpoint for public receipt checks.

Implemented receipt verification response model with valid flag and transaction summary fields.

Allowed anonymous access for verification path in security config while keeping other sales endpoints protected.

Added basic in-memory rate limiting for repeated failed verification attempts.

Extended repository with receipt lookup and added unit/integration tests for verification flow.

Tests: ./mvnw test (passed, 98 tests).